### PR TITLE
Fix parameter of MojoCollection

### DIFF
--- a/lib/Types/Mojo.pm
+++ b/lib/Types/Mojo.pm
@@ -14,6 +14,7 @@ use Type::Library
 use Type::Utils -all;
 use Types::Standard -types;
 
+use Carp;
 use Mojo::File;
 use Mojo::Collection;
 use Mojo::URL;
@@ -32,9 +33,10 @@ $meta->add_type(
     constraint_generator => sub {
         return $meta->get_type('MojoCollection') if !@_;
 
-        my $type  = $_[0];
-        my $check = $meta->get_type( $_[0] );
-        
+        my $check = $_[0] // '';
+        croak "Parameter to MojoCollection[`a] expected to be a type constraint; got $check"
+            if !blessed $check || !$check->isa('Type::Tiny');
+
         return sub {
             return if !blessed $_ and $_->isa('Mojo::Collection');
 

--- a/t/TestClass.pm
+++ b/t/TestClass.pm
@@ -7,7 +7,7 @@ use Types::Mojo qw(:all);
 has file => ( is => 'rw', isa => MojoFile, coerce => 1 );
 has coll => ( is => 'rw', isa => MojoCollection, coerce => 1 );
 has fl   => ( is => 'rw', isa => MojoFileList, coerce => 1 );
-has ints => ( is => 'rw', isa => MojoCollection["Int"], coerce => 1 );
+has ints => ( is => 'rw', isa => MojoCollection[Int], coerce => 1 );
 has ua   => ( is => 'rw', isa => MojoUserAgent );
 has url  => ( is => 'rw', isa => MojoURL, coerce => 1 );
 


### PR DESCRIPTION
MojoCollection doesn't support parametrized constraints like `InstanceOf['Foo']` yet. Thus a type like `MojoCollection[ InstanceOf['Foo'] ]` dies with an error during a check.

This pull request changes the parameter of MojoCollection to only allow Type::Tiny constraints. This means `MojoCollection['Str']` is not possible anymore and it must be called with a Type::Tiny constraint like `MojoCollection[Str]`.

This behavior is the same as ``ArrayRef[`a]`` from `Types::Standard` which also doesn't allow a scalar parameter.

Note: The error message of the parameter validation is thrown with Carp::croak. Perhaps there is better way. See `Type::Standard` which uses some internal methods.