### PR TITLE
Remove duplicate coercion of MojoCollection

### DIFF
--- a/lib/Types/Mojo.pm
+++ b/lib/Types/Mojo.pm
@@ -113,10 +113,6 @@ coerce MojoURL,
     from Str, via { Mojo::URL->new( $_ ) }
 ;
 
-coerce MojoCollection,
-    from ArrayRef, via { Mojo::Collection->new( @{$_} ) }
-;
-
 __PACKAGE__->meta->make_immutable;
 
 1;


### PR DESCRIPTION
When running "dzil listdeps --missing" for
PerlServices/API-MailboxOrg, Types::Mojo is listed even if it is installed. That's because Module::Runtime::require_module fails for it with

Attempt to add coercion code to a Type::Coercion which has been frozen at .../lib/perl5/Types/Mojo.pm line 118.

The exactly same coercion appears earlier at line 56.